### PR TITLE
Bump versions.jetty from 9.4.42.v20210604 to 9.4.43.v20210629

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
 
 def versions = [
         handlebars     : '4.2.0',
-        jetty          : '9.4.42.v20210604',
+        jetty          : '9.4.43.v20210629',
         guava          : '30.1.1-jre',
         jackson        : '2.12.3',
         xmlUnit        : '2.8.2'


### PR DESCRIPTION
Bumps `versions.jetty` from 9.4.42.v20210604 to 9.4.43.v20210629.

Updates `jetty-server` from 9.4.42.v20210604 to 9.4.43.v20210629
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.42.v20210604...jetty-9.4.43.v20210629)

Updates `jetty-servlet` from 9.4.42.v20210604 to 9.4.43.v20210629
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.42.v20210604...jetty-9.4.43.v20210629)

Updates `jetty-servlets` from 9.4.42.v20210604 to 9.4.43.v20210629
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.42.v20210604...jetty-9.4.43.v20210629)

Updates `jetty-webapp` from 9.4.42.v20210604 to 9.4.43.v20210629
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.42.v20210604...jetty-9.4.43.v20210629)

Updates `jetty-proxy` from 9.4.42.v20210604 to 9.4.43.v20210629
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.42.v20210604...jetty-9.4.43.v20210629)

Updates `http2-server` from 9.4.42.v20210604 to 9.4.43.v20210629

Updates `jetty-alpn-server` from 9.4.42.v20210604 to 9.4.43.v20210629

Updates `jetty-alpn-conscrypt-server` from 9.4.42.v20210604 to 9.4.43.v20210629

Updates `jetty-alpn-conscrypt-client` from 9.4.42.v20210604 to 9.4.43.v20210629

Updates `jetty-client` from 9.4.42.v20210604 to 9.4.43.v20210629
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.42.v20210604...jetty-9.4.43.v20210629)

Updates `http2-http-client-transport` from 9.4.42.v20210604 to 9.4.43.v20210629

---
updated-dependencies:
- dependency-name: org.eclipse.jetty:jetty-server
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty:jetty-servlet
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty:jetty-servlets
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty:jetty-webapp
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty:jetty-proxy
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty.http2:http2-server
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty:jetty-alpn-server
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty:jetty-alpn-conscrypt-server
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty:jetty-alpn-conscrypt-client
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty:jetty-client
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.eclipse.jetty.http2:http2-http-client-transport
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>