### PR TITLE
Bump versions.jackson from 2.12.3 to 2.12.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ def versions = [
         handlebars     : '4.2.0',
         jetty          : '9.4.42.v20210604',
         guava          : '30.1.1-jre',
-        jackson        : '2.12.3',
+        jackson        : '2.12.4',
         xmlUnit        : '2.8.2'
 ]
 


### PR DESCRIPTION
Bumps `versions.jackson` from 2.12.3 to 2.12.4.

Updates `jackson-core` from 2.12.3 to 2.12.4
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.12.3...jackson-core-2.12.4)

Updates `jackson-annotations` from 2.12.3 to 2.12.4
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-databind` from 2.12.3 to 2.12.4
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

---
updated-dependencies:
- dependency-name: com.fasterxml.jackson.core:jackson-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.core:jackson-annotations
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.core:jackson-databind
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>